### PR TITLE
Use latest miniconda3 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 before_install:
   - export MINICONDA=${HOME}/miniconda
   - export PATH=${MINICONDA}/bin:${PATH}
-  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -f -p ${MINICONDA}
   - conda config --set always_yes yes
   - conda env create -n my_env -f envs/create_db.yml


### PR DESCRIPTION
Miniconda-latest (without 2 or 3) does not seem to point to the latest version anymore? It caused issues with larger environments.
Maybe change this preemptively?